### PR TITLE
Register code highlight support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
         "0.1.0": "provideCodeFormat"
       }
     },
+    "code-highlight": {
+      "versions": {
+        "0.1.0": "provideCodeHighlight"
+      }
+    },
     "definitions": {
       "versions": {
         "0.1.0": "provideDefinitions"


### PR DESCRIPTION
Provides the `code-highlight` Atom service (via `atom-languageclient`).

Released under CC0.