### PR TITLE
Fix error on language server exit.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,7 @@ class JavaLanguageClient extends AutoLanguageClient {
           if (childProcess.killed !== true) {
             atom.notifications.addError('IDE-Java language server stopped unexpectedly.', {
               dismissable: true,
-              description: this.processStdErr != null ? `<code>${this.processStdErr}</code>` : `Exit code ${exitCode}`
+              description: this.processStdErr ? `<code>${this.processStdErr}</code>` : `Exit code ${exitCode}`
             })
           }
         })

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,8 +51,7 @@ class JavaLanguageClient extends AutoLanguageClient {
         const childProcess = cp.spawn(command, args, { cwd: serverHome })
         this.captureServerErrors(childProcess)
         childProcess.on('exit', exitCode => {
-          if (exitCode == 0 || exitCode == null) {
-          } else {
+          if (childProcess.killed !== true) {
             atom.notifications.addError('IDE-Java language server stopped unexpectedly.', {
               dismissable: true,
               description: this.processStdErr != null ? `<code>${this.processStdErr}</code>` : `Exit code ${exitCode}`

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ class JavaLanguageClient extends AutoLanguageClient {
         const childProcess = cp.spawn(command, args, { cwd: serverHome })
         this.captureServerErrors(childProcess)
         childProcess.on('exit', exitCode => {
-          if (childProcess.killed !== true) {
+          if (!childProcess.killed) {
             atom.notifications.addError('IDE-Java language server stopped unexpectedly.', {
               dismissable: true,
               description: this.processStdErr ? `<code>${this.processStdErr}</code>` : `Exit code ${exitCode}`

--- a/lib/main.js
+++ b/lib/main.js
@@ -57,6 +57,7 @@ class JavaLanguageClient extends AutoLanguageClient {
               description: this.processStdErr ? `<code>${this.processStdErr}</code>` : `Exit code ${exitCode}`
             })
           }
+          this.updateStatusBar('Stopped')
         })
         return childProcess
       }


### PR DESCRIPTION
One fix, two tweaks:
1) Using OpenJDK on Ubuntu Linux, the `java` process running the language server exits with a non-zero value when it receives SIGTERM. This causes ide-java to throw an error when the server exits normally. Not sure how it responds on other platforms, but this fix should work for everyone.

    atom-languageclient uses [`subprocess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal) to terminate the language server.

    After successfully killing the process in this manner, [`subprocess.killed`](https://nodejs.org/api/child_process.html#child_process_subprocess_killed) is set to `true`

    Rather than depend on the exit code, which turns out to be non-zero when we don't want it to be, I altered the "server unexpectedly stopped" error notification to only be shown if the server wasn't killed successfully by `subprocess.kill()`.

2) Only populate the error message with `this.processStdErr` if it is truthy. This fixes the case where `this.processStdErr` is displayed even if it is an empty string.

3) Status bar is updated to reflect when the server is stopped.
