### PR TITLE
Do not attach status bar info tile until necessary

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -192,6 +192,9 @@ class JavaLanguageClient extends AutoLanguageClient {
 
   updateStatusBar (text) {
     this.statusElement.textContent = `${this.name} ${text}`
+    if (!this.statusTile && this.statusBar) {
+      this.statusTile = this.statusBar.addRightTile({ item: this.statusElement, priority: 1000 })
+    }
   }
 
   actionableNotification (notification) {
@@ -242,7 +245,7 @@ class JavaLanguageClient extends AutoLanguageClient {
   }
 
   consumeStatusBar (statusBar) {
-    this.statusTile = statusBar.addRightTile({ item: this.statusElement, priority: 1000 })
+    this.statusBar = statusBar
   }
 
   fileExists (path) {


### PR DESCRIPTION
This prevents an empty status bar tile from being added, which causes subsequent status bar additions to look visually incorrect:
![status-bar-empty-tile](https://user-images.githubusercontent.com/2766036/32672122-39d53882-c64a-11e7-86c9-855c40cc9097.png)

The tile will only be added after the first `updateStatusBar` call.

(Also, the tile should probably have a class stating what it does, because it took me forever to figure out which package was adding this.)