### PR TITLE
Update jdt.ls to 0.12.1

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,9 +5,9 @@ const path = require('path')
 const {shell} = require('electron')
 const {AutoLanguageClient, DownloadFile} = require('atom-languageclient')
 
-const serverDownloadUrl = 'http://download.eclipse.org/jdtls/milestones/0.11.0/jdt-language-server-0.11.0-201801162212.tar.gz'
-const serverDownloadSize = 34931365
-const serverLauncher = '/plugins/org.eclipse.equinox.launcher_1.4.0.v20161219-1356.jar'
+const serverDownloadUrl = 'http://download.eclipse.org/jdtls/milestones/0.12.1/jdt-language-server-0.12.1-201802010347.tar.gz'
+const serverDownloadSize = 35864358
+const serverLauncher = '/plugins/org.eclipse.equinox.launcher_1.5.0.v20180119-0753.jar'
 const minJavaRuntime = 1.8
 const bytesToMegabytes = 1024 * 1024
 


### PR DESCRIPTION
brings better Java 9 support (performance, module-info.java editing), and test classpath isolation