### PR TITLE
Expand Java version detection

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -127,7 +127,7 @@ class JavaLanguageClient extends AutoLanguageClient {
   }
 
   getJavaVersionFromOutput (output) {
-    const match = output.match(/ version "(\d+(.\d+)?)(.\d+)?(_\d+)?"/)
+    const match = output.match(/ version "(\d+(.\d+)?)(.\d+)?(_\d+)?(?:-\w+)?"/)
     return match != null && match.length > 0 ? Number(match[1]) : null
   }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -14,10 +14,26 @@ describe('main', () => {
       expect(version).to.be.equal(1.8)
     })
 
-    it('returns 1.8 for OpenJDK 1.8', () => {
+    it('returns 1.8 for OpenJDK 1.8 (ubuntu)', () => {
       const version = JavaLanguageClient.getJavaVersionFromOutput('openjdk version "1.8.0_131"'
         + '\nOpenJDK Runtime Environment (build 1.8.0_131-8u131-b11-2ubuntu1.17.04.3-b11)'
         + '\nOpenJDK 64-Bit Server VM (build 25.131-b11, mixed mode)')
+      expect(version).to.be.equal(1.8)
+    })
+
+    it('returns 1.8 for OpenJDK 1.8 (custom)', () => {
+      // #54
+      const version = JavaLanguageClient.getJavaVersionFromOutput('openjdk version "1.8.0_172-solus"'
+        + '\nOpenJDK Runtime Environment (build 1.8.0_172-solus-b00)'
+        + '\nOpenJDK 64-Bit Server VM (build 25.172-b00, mixed mode)')
+      expect(version).to.be.equal(1.8)
+    })
+
+    it('returns 1.8 for OpenJDK 1.8 (macOS)', () => {
+      // #62
+      const version = JavaLanguageClient.getJavaVersionFromOutput('openjdk version "1.8.0_152-release"'
+        + '\nOpenJDK Runtime Environment (build 1.8.0_152-release-915-b08)'
+        + '\nOpenJDK 64-Bit Server VM (build 25.152-b08, mixed mode)')
       expect(version).to.be.equal(1.8)
     })
 


### PR DESCRIPTION
Several older OpenJDK versions seem to add more text to their `java --showVersion` output than was previously expected. Allow this additional text to not break the version detection checks.

Fixes #54.
Fixes #62.