### PR TITLE
Support `javaExtensions`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -190,6 +190,22 @@ class JavaLanguageClient extends AutoLanguageClient {
     connection.onCustom('language/actionableNotification', this.actionableNotification.bind(this))
   }
 
+  getInitializeParams(projectPath, process) {
+    const params = super.getInitializeParams(projectPath, process);
+    if (!params.initializationOptions) {
+      params.initializationOptions = {};
+    }
+    params.initializationOptions.bundles = this.collectJavaExtensions();
+    return params;
+  }
+
+  collectJavaExtensions() {
+    return atom.packages.getLoadedPackages()
+        .filter(pkg => Array.isArray(pkg.metadata.javaExtensions))
+        .map(pkg => pkg.metadata.javaExtensions.map(p => path.resolve(pkg.path, p)))
+        .reduce(e => e.concat([]));
+  }
+
   updateInstallStatus (status) {
     const isComplete = status === 'installed'
     if (this.busySignalService) {


### PR DESCRIPTION
VSCode has support RedHat Java LS extensions/plugins: https://github.com/redhat-developer/vscode-java/wiki/Contribute-a-Java-Extension
This needs to be mirrored in Atom because the LS is the same I think.