### PR TITLE
Add console as a consumed service

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
         "0.1.0": "consumeBusySignal"
       }
     },
+    "console": {
+      "versions": {
+        "0.1.0": "consumeConsole"
+      }
+    },
     "datatip": {
       "versions": {
         "0.1.0": "consumeDatatip"


### PR DESCRIPTION
Could also add opening the Atom IDE Console automatically to this if desired but this will at least get more detailed error messages into the editor.

Closes #68 