### PR TITLE
[DO NOT MERGE] Support `workspace/executeClientCommand` protocol extension

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,9 +11,9 @@ const {
   removeUnusedImportProvider
 } = actionProviders
 
-const serverDownloadUrl = 'http://download.eclipse.org/jdtls/milestones/0.14.0/jdt-language-server-0.14.0-201802282111.tar.gz'
+const serverDownloadUrl = 'http://download.eclipse.org/jdtls/milestones/0.17.0/jdt-language-server-0.17.0-201804162308.tar.gz'
 const serverDownloadSize = 35873467
-const serverLauncher = '/plugins/org.eclipse.equinox.launcher_1.5.0.v20180119-0753.jar'
+const serverLauncher = '/plugins/org.eclipse.equinox.launcher_1.5.0.v20180207-1446.jar'
 const minJavaRuntime = 1.8
 const bytesToMegabytes = 1024 * 1024
 
@@ -83,6 +83,19 @@ class JavaLanguageClient extends AutoLanguageClient {
         return childProcess
       }
     )
+  }
+
+  postInitialization(server) {
+    server.connection._onRequest( {method: 'workspace/executeClientCommand'}, params => this.executeClientCommand(params));
+  }
+
+  executeClientCommand(params) {
+    const commands = this.getLspCommandsRegistry();
+    return commands.execute(params.command, params.arguments);
+  }
+
+  getLspCommandsRegistry() {
+    return global.lspCommandRegistry;
   }
 
   checkJavaVersion (command) {
@@ -209,7 +222,7 @@ class JavaLanguageClient extends AutoLanguageClient {
     return atom.packages.getLoadedPackages()
         .filter(pkg => Array.isArray(pkg.metadata.javaExtensions))
         .map(pkg => pkg.metadata.javaExtensions.map(p => path.resolve(pkg.path, p)))
-        .reduce(e => e.concat([]), []);
+        .reduce((a, e) => a.concat(e));
   }
 
   updateInstallStatus (status) {


### PR DESCRIPTION
Fixes #78 
Depends on https://github.com/atom/atom-languageclient/pull/215

Provides support for `workspace/executeClientCommand`. The support is done via `LsCommandsRegistry` implemented in https://github.com/atom/atom-languageclient/pull/215 which kind of a weak link because it introduces new API...

Looking for feedback.