### PR TITLE
Exit check version on close (from exit)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -100,7 +100,7 @@ class JavaLanguageClient extends AutoLanguageClient {
       let stdErr = '', stdOut = ''
       childProcess.stderr.on('data', chunk => stdErr += chunk.toString())
       childProcess.stdout.on('data', chunk => stdOut += chunk.toString())
-      childProcess.on('exit', exitCode => {
+      childProcess.on('close', exitCode => {
         const output = stdErr + '\n' + stdOut
         if (exitCode === 0 && output.length > 2) {
           const version = this.getJavaVersionFromOutput(output)


### PR DESCRIPTION
Was getting an error about `IDE-Java encounted an error using the Java runtime`, found that the output of the command to check the Java version returned empty sometimes.

From child_process docs:
> Note that when the 'exit' event is triggered, child process stdio streams might still be open.

So it became a race between the `exit`, and the `data` events which led to patchy errors (e.g., disabling and renabling the package worked as a solution every time you restarted Atom).

This PR changes the event to `close`, which is specified as follows
> Event: 'close'#
Added in: v0.7.7
code <number> The exit code if the child exited on its own.
signal <string> The signal by which the child process was terminated.
The 'close' event is emitted when the stdio streams of a child process have been closed. This is distinct from the 'exit' event, since multiple processes might share the same stdio streams.

Testing seems to confirm no more errors. At least, I didn't encounter one with `close`, and swapping back to `exit` started them again.

Fixes #51 (which is currently closed right now)