### PR TITLE
Future proof mkdir and tidying

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -100,7 +100,7 @@ class JavaLanguageClient extends AutoLanguageClient {
       let stdErr = '', stdOut = ''
       childProcess.stderr.on('data', chunk => stdErr += chunk.toString())
       childProcess.stdout.on('data', chunk => stdOut += chunk.toString())
-      childProcess.on('exit', exitCode => {
+      childProcess.on('close', exitCode => {
         const output = stdErr + '\n' + stdOut
         if (exitCode === 0 && output.length > 2) {
           const version = this.getJavaVersionFromOutput(output)

--- a/lib/main.js
+++ b/lib/main.js
@@ -71,7 +71,7 @@ class JavaLanguageClient extends AutoLanguageClient {
         this.logger.debug(`starting "${command} ${args.join(' ')}"`)
         const childProcess = cp.spawn(command, args, { cwd: serverHome })
         this.captureServerErrors(childProcess)
-        childProcess.on('exit', exitCode => {
+        childProcess.on('close', exitCode => {
           if (!childProcess.killed) {
             atom.notifications.addError('IDE-Java language server stopped unexpectedly.', {
               dismissable: true,

--- a/lib/main.js
+++ b/lib/main.js
@@ -164,7 +164,7 @@ class JavaLanguageClient extends AutoLanguageClient {
   getOrCreateDataDir (projectPath) {
     const dataDir = path.join(os.tmpdir(), `atom-java-${encodeURIComponent(projectPath)}`)
     return this.fileExists(dataDir)
-      .then(exists => { if (!exists) return fs.mkdir(dataDir) })
+      .then(exists => { if (!exists) fs.mkdirSync(dataDir, { recursive: true }, err => { if (err) throw err }) })
       .then(() => dataDir)
   }
 
@@ -180,9 +180,12 @@ class JavaLanguageClient extends AutoLanguageClient {
   installServer (serverHome) {
     const localFileName = path.join(serverHome, 'download.tar.gz')
     const decompress = require('decompress')
+    const provideInstallStatus = (bytesDone, percent) => {
+      this.updateInstallStatus(`downloading ${Math.floor(serverDownloadSize / bytesToMegabytes)} MB (${percent}% done)`)
+    }
     return this.fileExists(serverHome)
-      .then(doesExist => { if (!doesExist) fs.mkdirSync(serverHome) })
-      .then(() => DownloadFile(serverDownloadUrl, localFileName, (bytesDone, percent) => this.updateInstallStatus(`downloading ${Math.floor(serverDownloadSize / bytesToMegabytes)} MB (${percent}% done)`), serverDownloadSize))
+      .then(doesExist => { if (!doesExist) fs.mkdirSync(serverHome, { recursive: true }, err => { if (err) throw err }) })
+      .then(() => DownloadFile(serverDownloadUrl, localFileName, provideInstallStatus, serverDownloadSize))
       .then(() => this.updateInstallStatus('unpacking'))
       .then(() => decompress(localFileName, serverHome))
       .then(() => this.fileExists(path.join(serverHome, serverLauncher)))
@@ -298,7 +301,7 @@ class JavaLanguageClient extends AutoLanguageClient {
   }
 
   fileExists (path) {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       fs.access(path, fs.R_OK, error => {
         resolve(!error || error.code !== 'ENOENT')
       })

--- a/lib/main.js
+++ b/lib/main.js
@@ -164,7 +164,7 @@ class JavaLanguageClient extends AutoLanguageClient {
   getOrCreateDataDir (projectPath) {
     const dataDir = path.join(os.tmpdir(), `atom-java-${encodeURIComponent(projectPath)}`)
     return this.fileExists(dataDir)
-      .then(exists => { if (!exists) fs.mkdirSync(dataDir, { recursive: true }, err => { if (err) throw err }) })
+      .then(exists => { if (!exists) fs.mkdirSync(dataDir, { recursive: true }) })
       .then(() => dataDir)
   }
 
@@ -184,7 +184,7 @@ class JavaLanguageClient extends AutoLanguageClient {
       this.updateInstallStatus(`downloading ${Math.floor(serverDownloadSize / bytesToMegabytes)} MB (${percent}% done)`)
     }
     return this.fileExists(serverHome)
-      .then(doesExist => { if (!doesExist) fs.mkdirSync(serverHome, { recursive: true }, err => { if (err) throw err }) })
+      .then(doesExist => { if (!doesExist) fs.mkdirSync(serverHome, { recursive: true }) })
       .then(() => DownloadFile(serverDownloadUrl, localFileName, provideInstallStatus, serverDownloadSize))
       .then(() => this.updateInstallStatus('unpacking'))
       .then(() => decompress(localFileName, serverHome))


### PR DESCRIPTION
- Make the directory synchonously. This is makes it the same as the other directory construction part. Also closes #95, as callbacks aren't needed for the sync version.
- Add `{ recursive: true }` to both, which shouldn't be necessary but doesn't hurt either.
- Refacor out the update progress function to reduce the max line length of the file