### PR TITLE
Enable sending configuration changes to the language server

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -211,7 +211,6 @@ class JavaLanguageClient extends AutoLanguageClient {
       params.initializationOptions = {};
     }
     params.initializationOptions.bundles = this.collectJavaExtensions();
-    params.initializationOptions.settings = atom.config.get(this.getRootConfigurationKey())
     return params;
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,6 +21,8 @@ class JavaLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return [ 'source.java' ] }
   getLanguageName () { return 'Java' }
   getServerName () { return 'Eclipse JDT' }
+  getRootConfigurationKey() { return 'ide-java.server' }
+  mapConfigurationObject(configuration) { return {java: configuration} }
 
   constructor () {
     super()
@@ -28,8 +30,10 @@ class JavaLanguageClient extends AutoLanguageClient {
     this.statusElement.className = 'inline-block'
 
     this.commands = {
-      'java.ignoreIncompleteClasspath': () => { atom.config.set('ide-java.errors.incompleteClasspathSeverity', 'ignore') },
-      'java.ignoreIncompleteClasspath.help': () => { shell.openExternal('https://github.com/atom/ide-java/wiki/Incomplete-Classpath-Warning') }
+      'java.ignoreIncompleteClasspath': () => {
+        atom.config.set('ide-java.server.errors.incompleteClasspath.severity', 'ignore')
+      },
+      'java.ignoreIncompleteClasspath.help': () => { shell.openExternal('https://github.com/atom/ide-java/wiki/Incomplete-Classpath-Warning') },
     }
   }
 
@@ -196,7 +200,7 @@ class JavaLanguageClient extends AutoLanguageClient {
 
   preInitialization(connection) {
     connection.onCustom('language/status', (e) => this.updateStatusBar(`${e.type.replace(/^Started$/, '')} ${e.message}`))
-    connection.onCustom('language/actionableNotification', this.actionableNotification.bind(this))
+    connection.onCustom('language/actionableNotification', (notification) => this.actionableNotification(notification, connection))
   }
 
   getInitializeParams(projectPath, process) {
@@ -205,11 +209,7 @@ class JavaLanguageClient extends AutoLanguageClient {
       params.initializationOptions = {};
     }
     params.initializationOptions.bundles = this.collectJavaExtensions();
-    params.initializationOptions.settings = {
-      java: {
-        "java.signatureHelp.enabled": true
-      }
-    }
+    params.initializationOptions.settings = atom.config.get(this.getRootConfigurationKey())
     return params;
   }
 
@@ -246,39 +246,23 @@ class JavaLanguageClient extends AutoLanguageClient {
     }
   }
 
-  actionableNotification (notification) {
-    if (notification.message.startsWith('Classpath is incomplete.')) {
-      switch(atom.config.get('ide-java.errors.incompleteClasspathSeverity')) {
-        case 'ignore': return
-        case 'error': {
-          notification.severity = 1
-          break
-        }
-        case 'warning': {
-          notification.severity = 2
-          break
-        }
-        case 'info': {
-          notification.severity = 3
-          break
-        }
-      }
-    }
-
+  actionableNotification (notification, connection) {
     const options = { dismissable: true, detail: this.getServerName() }
     if (Array.isArray(notification.commands)) {
-      options.buttons = notification.commands.map(c => ({ text: c.title, onDidClick: (e) => onActionableButton(e, c.command) }))
-      // TODO: Deal with the actions
+      options.buttons = notification.commands.map(command => ({
+        text: command.title,
+        onDidClick: () => onActionableButton(command)
+      }))
     }
 
     const notificationDialog = this.createNotification(notification.severity, notification.message, options)
 
-    const onActionableButton = (event, commandName) => {
-      const commandFunction = this.commands[commandName]
+    const onActionableButton = (command) => {
+      const commandFunction = this.commands[command.command]
       if (commandFunction != null) {
-        commandFunction()
+        commandFunction(command, connection)
       } else {
-        console.log(`Unknown actionableNotification command '${commandName}'`)
+        console.log(`Unknown actionableNotification command '${command.command}'`)
       }
       notificationDialog.dismiss()
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,14 @@ class JavaLanguageClient extends AutoLanguageClient {
         atom.config.set('ide-java.server.errors.incompleteClasspath.severity', 'ignore')
       },
       'java.ignoreIncompleteClasspath.help': () => { shell.openExternal('https://github.com/atom/ide-java/wiki/Incomplete-Classpath-Warning') },
+
+    // Migrate ide-java.errors.incompleteClasspathSeverity -> ide-java.server.errors.incompleteClasspath.severity
+    // Migration added in v0.10.0; feel free to remove after a few versions
+    const severity = atom.config.get('ide-java.errors.incompleteClasspathSeverity')
+    if (severity) {
+      atom.config.unset('ide-java.errors.incompleteClasspathSeverity')
+      atom.config.unset('ide-java.errors')
+      atom.config.set('ide-java.server.errors.incompleteClasspath.severity', severity)
     }
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,7 @@ class JavaLanguageClient extends AutoLanguageClient {
         atom.config.set('ide-java.server.errors.incompleteClasspath.severity', 'ignore')
       },
       'java.ignoreIncompleteClasspath.help': () => { shell.openExternal('https://github.com/atom/ide-java/wiki/Incomplete-Classpath-Warning') },
+    }
 
     // Migrate ide-java.errors.incompleteClasspathSeverity -> ide-java.server.errors.incompleteClasspath.severity
     // Migration added in v0.10.0; feel free to remove after a few versions

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,6 +21,8 @@ class JavaLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return [ 'source.java' ] }
   getLanguageName () { return 'Java' }
   getServerName () { return 'Eclipse JDT' }
+  // List of preferences available at:
+  // https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
   getRootConfigurationKey() { return 'ide-java.server' }
   mapConfigurationObject(configuration) { return {java: configuration} }
 

--- a/package.json
+++ b/package.json
@@ -29,22 +29,46 @@
         }
       }
     },
-    "errors": {
+    "server": {
       "order": 30,
       "type": "object",
-      "title": "Warnings and Errors",
+      "title": "Language Server",
+      "description": "Settings that control language server functionality.",
       "properties": {
-        "incompleteClasspathSeverity": {
-          "type": "string",
-          "title": "Incomplete Classpath Severity",
-          "enum": [
-            "ignore",
-            "info",
-            "warning",
-            "error"
-          ],
-          "default": "warning",
-          "description": "Severity of the message when the classpath is incomplete for a Java file."
+        "signatureHelp": {
+          "type": "object",
+          "title": "Signature Help",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Controls whether signature help is enabled."
+            }
+          }
+        },
+        "errors": {
+          "type": "object",
+          "title": "Warnings and Errors",
+          "properties": {
+            "incompleteClasspath": {
+              "type": "object",
+              "title": "Incomplete Classpath",
+              "properties": {
+                "severity": {
+                  "type": "string",
+                  "title": "Incomplete Classpath Severity",
+                  "enum": [
+                    "ignore",
+                    "info",
+                    "warning",
+                    "error"
+                  ],
+                  "default": "warning",
+                  "description": "Severity of the message when the classpath is incomplete for a Java file."
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The Eclipse language server contains [many](https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java) preferences that the client can configure to control its behavior. Up until now, there was no way to change any of those preferences. With this PR, I've:
1. Restructured the package settings to match the structure that the language server expects
2. Hooked into the relevant atom-languageclient functions so that
    * settings are passed to the language server on load, and
    * the language server receives updated configurations whenever ide-java settings change
3. Removed the special-casing for the incomplete classpath notification, now that we can properly configure the language server to not send a notification
4. Exposed the enabling of signature help as an option (and fixed it so that it actually works in the first place)