### PR TITLE
Add support for updating build configuration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,22 @@ class JavaLanguageClient extends AutoLanguageClient {
         atom.config.set('ide-java.server.errors.incompleteClasspath.severity', 'ignore')
       },
       'java.ignoreIncompleteClasspath.help': () => { shell.openExternal('https://github.com/atom/ide-java/wiki/Incomplete-Classpath-Warning') },
+      'java.projectConfiguration.status': (command, connection) => {
+        // Arguments:
+        // - 0: Object containing build file URI
+        // - 1: 'disabled' for Never, 'interactive' for Now, 'automatic' for Always
+        const [uri, status] = command.arguments
+        const statusMap = {
+          0: 'disabled',
+          1: 'interactive',
+          2: 'automatic',
+        }
+        atom.config.set('ide-java.server.configuration.updateBuildConfiguration', statusMap[status])
+
+        if (status !== 0) {
+          connection.sendCustomRequest('java/projectConfigurationUpdate', uri)
+        }
+      }
     }
 
     // Migrate ide-java.errors.incompleteClasspathSeverity -> ide-java.server.errors.incompleteClasspath.severity
@@ -210,7 +226,16 @@ class JavaLanguageClient extends AutoLanguageClient {
   }
 
   preInitialization(connection) {
-    connection.onCustom('language/status', (e) => this.updateStatusBar(`${e.type.replace(/^Started$/, '')} ${e.message}`))
+    let started = false
+    connection.onCustom('language/status', (status) => {
+      if (started) return
+      this.updateStatusBar(status.message)
+      // Additional messages can be generated after the server is ready
+      // that we don't want to show (for example, build refreshes)
+      if (status.type === 'Started') {
+        started = true
+      }
+    })
     connection.onCustom('language/actionableNotification', (notification) => this.actionableNotification(notification, connection))
   }
 

--- a/package.json
+++ b/package.json
@@ -35,12 +35,30 @@
       "title": "Language Server",
       "description": "Settings that control language server functionality.",
       "properties": {
+        "configuration": {
+          "type": "object",
+          "title": "Project Configuration",
+          "properties": {
+            "updateBuildConfiguration": {
+              "type": "string",
+              "title": "Update Build Configuration",
+              "enum": [
+                {"value": "disabled", "description": "Never"},
+                {"value": "interactive", "description": "Ask every time"},
+                {"value": "automatic", "description": "Always"}
+              ],
+              "default": "interactive",
+              "description": "Whether to automatically update the project configuration when build files change."
+            }
+          }
+        },
         "signatureHelp": {
           "type": "object",
           "title": "Signature Help",
           "properties": {
             "enabled": {
               "type": "boolean",
+              "title": "Enabled",
               "default": true,
               "description": "Controls whether signature help is enabled."
             }


### PR DESCRIPTION
This builds off of #110 by adding proper support for updating the build configuration when a build file changes. Previously, a notification would be generated, but none of the options would do anything. Here, I have:
1. Implemented the callback function for `java.projectConfiguration.status`, so that no more "Unknown actionableNotification command" messages are generated.
2. Added a config setting to locally persist the value chosen (as well as persisted by the LS per-session).
3. Implemented the request to regenerate the build configuration based on the option chosen.
4. Updated the `language/status` callback to stop reporting statuses after the server is ready, as additional unneeded messages are reported when updating the build configuration.

Fixes #108