### PR TITLE
Add settings for formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,63 @@
             }
           }
         },
+        "format": {
+          "type": "object",
+          "title": "Format",
+          "properties": {
+            "enabled": {
+              "order": 1,
+              "type": "boolean",
+              "title": "Enabled",
+              "default": true,
+              "description": "Controls whether formatting is enabled."
+            },
+            "comments": {
+              "type": "object",
+              "title": "Comments",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Enabled",
+                  "default": true,
+                  "description": "Include comments when formatting."
+                }
+              }
+            },
+            "onType": {
+              "type": "object",
+              "title": "On Type",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Enabled",
+                  "default": true,
+                  "description": "Format code as you type."
+                }
+              }
+            },
+            "settings": {
+              "type": "object",
+              "title": "Settings",
+              "properties": {
+                "url": {
+                  "order": 1,
+                  "type": "string",
+                  "title": "URL",
+                  "default": "",
+                  "description": "URL to an XML file specifying format options."
+                },
+                "profile": {
+                  "order": 2,
+                  "type": "string",
+                  "title": "Profile Name",
+                  "default": "",
+                  "description": "Name of the formatter profile to use. Has no effect unless a formatter URL is specified."
+                }
+              }
+            }
+          }
+        },
         "signatureHelp": {
           "type": "object",
           "title": "Signature Help",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,17 @@
     },
     "code-format.range": {
       "versions": {
-        "0.1.0": "provideCodeFormat"
+        "0.1.0": "provideRangeCodeFormat"
+      }
+    },
+    "code-format.file": {
+      "versions": {
+        "0.1.0": "provideFileCodeFormat"
+      }
+    },
+    "code-format.onType": {
+      "versions": {
+        "0.1.0": "provideOnTypeCodeFormat"
       }
     },
     "code-highlight": {

--- a/package.json
+++ b/package.json
@@ -218,6 +218,11 @@
         "0.1.0": "provideOnTypeCodeFormat"
       }
     },
+    "code-format.onSave": {
+      "versions": {
+        "0.1.0": "provideOnSaveCodeFormat"
+      }
+    },
     "code-highlight": {
       "versions": {
         "0.1.0": "provideCodeHighlight"


### PR DESCRIPTION
Makes all the formatting settings from the LS configurable :tada:. And now that we have this additional level of configuration, I figure it's a good time to hook into the format-on-type and format-on-save providers. On-type can be disabled within ide-java, and on-save can be disabled via atom-ide-ui.

I still need to figure out how to make this a smooth transition, though, as I'm sure most projects aren't following Eclipse's default formatting rules.

Fixes #109