### PR TITLE
fix: Support auto-import for annotations

### DIFF
--- a/lib/providers/autoImportActionProvider.js
+++ b/lib/providers/autoImportActionProvider.js
@@ -118,6 +118,7 @@ function getImportChoice(missingType, editor, typeRange, languageClient) {
 function buildImportSuggestion(autocompleteSuggestion) {
   switch (autocompleteSuggestion.type) {
   case 'class':
+  case 'mixin':
     const { displayText } = autocompleteSuggestion
     const [ typeName, pkgName ] = displayText.split('-').map(s => s.trim())
 

--- a/test/autoImportActionProvider.test.js
+++ b/test/autoImportActionProvider.test.js
@@ -78,6 +78,25 @@ describe.only('autoImportActionProvider', () => {
       })
     })
 
+    describe('Suggestion Type: `mixin`', () => {
+      it('should build the correct import package path', () => {
+        const suggestion = {
+          type: 'mixin',
+          displayText: 'PostMessage - org.springframework.web.bind.annotation'
+        }
+
+        expect(buildImportSuggestion(suggestion)).to.equal('org.springframework.web.bind.annotation.PostMessage')
+      })
+
+      it('should throw error if type or package name is missing', () => {
+        try {
+          expect.fail('Should have thrown error')
+        } catch (error) {
+          expect(error).not.to.be.null
+        }
+      })
+    })
+
     it('should throw error for unknown suggestion type', () => {
       try {
         buildImportSuggestion({ type: 'unknown type' })


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

#114 

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

atom-languageclient considers interfaces as being of type `mixin`, and (many?) annotations are interfaces. Since `buildImportSuggestion` does not handle the `mixin` type interfaces cannot be auto-imported.

This change treats interfaces same as classes, which seems to me is the correct behaviour, seeing as interfaces are types without an implementation.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
I did not consider alternate designs, although I am open to discussion about this fix.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I see no obvious drawbacks.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

- Trigger imports of various types

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fixed an issue where auto-import of interfaces would fail.