### PR TITLE
Fix auto import for enums

### DIFF
--- a/lib/providers/autoImportActionProvider.js
+++ b/lib/providers/autoImportActionProvider.js
@@ -118,6 +118,7 @@ function getImportChoice(missingType, editor, typeRange, languageClient) {
 function buildImportSuggestion(autocompleteSuggestion) {
   switch (autocompleteSuggestion.type) {
   case 'class':
+  case 'enum':
     const { displayText } = autocompleteSuggestion
     const [ typeName, pkgName ] = displayText.split('-').map(s => s.trim())
 

--- a/test/autoImportActionProvider.test.js
+++ b/test/autoImportActionProvider.test.js
@@ -78,6 +78,25 @@ describe.only('autoImportActionProvider', () => {
       })
     })
 
+    describe('Suggestion Type: `enum`', () => {
+      it('should build the correct import package path', () => {
+        const suggestion = {
+          type: 'enum',
+          displayText: 'Month - java.time'
+        }
+
+        expect(buildImportSuggestion(suggestion)).to.equal('java.time.Month')
+      })
+
+      it('should throw error if type or package name is missing', () => {
+        try {
+          expect.fail('Should have thrown error')
+        } catch (error) {
+          expect(error).not.to.be.null
+        }
+      })
+    })
+
     it('should throw error for unknown suggestion type', () => {
       try {
         buildImportSuggestion({ type: 'unknown type' })


### PR DESCRIPTION
### Identify the Bug

Issue #130 

### Description of the Change

The ```buildImportSuggestion``` function seems to not consider ```enums``` when performing the auto import functionality.

This change considers enums as classes when performing the auto import functionality.

### Alternate Designs

I've been using PR #120 for issue #114 as a guide line.

### Possible Drawbacks

None that I've notice.

### Verification Process

- Running the test suite;
- Triggering imports of other types.

### Release Notes

Fixed an issue when trying to auto import enums.
